### PR TITLE
fixed bug in setting background

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: facilitator_database
 Title: Update Google Sheets Views of Youth Impact Facilitator Database
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person("Jake", "Hughey", , "jakejhughey@gmail.com", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
@@ -8,15 +8,15 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
-Depends: R (>= 4.2.0)
+Depends: R (>= 4.3.3)
 Imports:
-  cli (>= 3.6.0),
-  checkmate (>= 2.1.0),
-  data.table (>= 1.14.7),
-  gargle (>= 1.3.0),
-  glue (>= 1.6.2),
-  googledrive (>= 2.0.0),
-  googlesheets4 (>= 1.0.1),
-  yaml (>= 2.3.7)
+  cli (>= 3.6.2),
+  checkmate (>= 2.3.1),
+  data.table (>= 1.15.1),
+  gargle (>= 1.5.2),
+  glue (>= 1.7.0),
+  googledrive (>= 2.1.1),
+  googlesheets4 (>= 1.1.1),
+  yaml (>= 2.3.8)
 Remotes:
   Rdatatable/data.table

--- a/code/setup.R
+++ b/code/setup.R
@@ -503,17 +503,18 @@ drive_get_background = function(file_id, sheet, range, nonwhite = TRUE) {
 #'   and `blue`.
 #'
 #' @return The result of [googlesheets4::request_make()], invisibly.
-drive_set_background = function(file_id, background) {
+drive_set_background = function(file_id, background, sheet) {
   assert_class(file_id, 'drive_id')
   assert_data_table(background)
 
   # only for setting one color per entire column
-  gfile = drive_get(file_id)
+  gfile = gs4_get(file_id)
   cli_alert_success('Setting background colors for "{gfile$name}".')
 
   bod_base = '{
   "repeatCell": {
     "range": {
+      "sheetId": (sheet_id),
       "startColumnIndex": (start_col),
       "endColumnIndex": (start_col + 1)
     },
@@ -531,6 +532,7 @@ drive_set_background = function(file_id, background) {
   }'
 
   background = copy(background)
+  background[, sheet_id := gfile$sheets$id[gfile$sheets$name == sheet]]
   background[, bod := glue(bod_base, .envir = .SD, .open = '(', .close = ')')]
   bod = sprintf('{"requests": [%s]}', paste(background$bod, collapse = ',\n'))
 
@@ -652,7 +654,7 @@ set_views = function(x, bg, prefix, sheet) {
     # update formatting
     bg_now = bg[column_name %in% cols_now]
     bg_now[, start_col := match(column_name, cols_now) - 1L]
-    drive_set_background(file_id, bg_now)
+    drive_set_background(file_id, bg_now, sheet)
 
     # update permissions
     viewers_now = x$viewers[group_id == group_id_now]

--- a/code/setup.R
+++ b/code/setup.R
@@ -501,6 +501,7 @@ drive_get_background = function(file_id, sheet, range, nonwhite = TRUE) {
 #' @param file_id A `drive_id` corresponding to a Drive file.
 #' @param background A `data.table` having columns `start_col`, `red`, `green`,
 #'   and `blue`.
+#' @param sheet A string indicating the worksheet name in the Google Sheet.
 #'
 #' @return The result of [googlesheets4::request_make()], invisibly.
 drive_set_background = function(file_id, background, sheet) {


### PR DESCRIPTION
The previous version did not specify a `sheetId` when making the API request, so the API was defaulting to `sheetId` 0, which corresponds to the first sheet created in the spreadsheet and not necessarily to the sheet named "Cases". Now the code explicitly finds which `sheetId` to set colors for.